### PR TITLE
Fix minimal notebook

### DIFF
--- a/examples/minimal_notebook.ipynb
+++ b/examples/minimal_notebook.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Intro to DLC2Action (mini)"
+    "# Intro to DLC2Action (mini)\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/amathislab/DLC2action/blob/master/examples/minimal_notebook.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -36,7 +38,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's download the data. Downloading the data and installing the packages can take up to about 5-10 minutes."
+    "## Setup - Installing Packages and Downloading Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Downloading the data and installing the packages can take up to about 5-10 minutes.\n",
+    "\n",
+    "First, let's download the data."
    ]
   },
   {
@@ -45,11 +56,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#download the data\n",
-    "!curl https://transfer.sh/g8t8Vy/OFT.zip -o OFT.zip\n",
+    "!wget https://github.com/ETHZ-INS/DLCAnalyzer/archive/refs/heads/master.zip\n",
     "!apt-get install unzip\n",
-    "!unzip OFT.zip -d OFT\n",
-    "!mv OFT/OFT/OFT OFT_data"
+    "!unzip master.zip\n",
+    "!mv DLCAnalyzer-master/data/OFT OFT_data"
    ]
   },
   {
@@ -65,21 +75,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python -m pip install dlc2action"
+    "!pip install dlc2action"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DLC2Action"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we need to import the necessary packages and specify where our data is."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dlc2action.project import Project\n",
     "import os\n",
+    "import pandas as pd\n",
+    "from dlc2action.project import Project\n",
     "\n",
     "CURRENT_PATH = os.getcwd()\n",
-    "DATA_PATH = os.path.join(CURRENT_PATH, \"OFT\", \"OFT\", \"Output_DLC\")\n",
-    "LABELS_PATH = os.path.join(CURRENT_PATH, \"OFT\", \"OFT\", \"Labels\")\n",
+    "DATA_PATH = os.path.join(CURRENT_PATH, \"OFT_data\", \"Output_DLC\")\n",
+    "LABELS_PATH = os.path.join(CURRENT_PATH, \"OFT_data\", \"Labels\")\n",
     "PROJECTS_PATH = os.path.join(CURRENT_PATH, \"DLC2Action\")"
    ]
   },
@@ -87,6 +112,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Then, we need to parse the data for it to be in a format that can be read by `dlc2action` (one annotation file per video)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annotations = f\"{LABELS_PATH}/AllLabDataOFT_final.csv\"\n",
+    "\n",
+    "# loading the annotations\n",
+    "df_labels = pd.read_csv(annotations, sep=\";\")\n",
+    "\n",
+    "# Getting the video name from the dlc filename\n",
+    "model = \"DeepCut_resnet50_Blockcourse1May9shuffle1_1030000.csv\"\n",
+    "df_labels[\"video\"] = df_labels[\"DLCFile\"].map(lambda dlc_file: dlc_file.split(model)[0])\n",
+    "\n",
+    "# Splitting the data into one csv for each video\n",
+    "videos = df_labels[\"video\"].unique()\n",
+    "for video in videos:\n",
+    "    df_video_labels = df_labels[df_labels[\"video\"] == video]\n",
+    "    df_video_labels = df_video_labels.drop(\"video\", axis=1)\n",
+    "    df_video_labels.to_csv(f\"{LABELS_PATH}/{video}.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can move on to `DLC2Action`.\n",
+    "\n",
     "High-level methods in DLC2Action are almost exclusively accessed through the `dlc2action.project.Project` class. A project instance should loosely correspond to a specific goal (e.g. generating automatic annotations for dataset A with input format X). You can use it to optimize hyperparameters, run experiments, analyze results and generate new data.\n",
     "\n",
     "**Best practices**\n",
@@ -109,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setting parameters"
+    "### Setting parameters"
    ]
   },
   {
@@ -142,17 +199,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "There is no blanks left!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "project.list_blanks()"
    ]
@@ -168,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +251,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Hyperparameter search"
+    "### Hyperparameter search"
    ]
   },
   {
@@ -216,428 +265,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "SEARCH test_search\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m[I 2022-11-23 23:18:23,230]\u001b[0m A new study created in memory with name: no-name-688601f8-98fc-4905-9988-f7e2abcdb4e3\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Computing input features...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:14<00:00,  1.35it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Computing annotation arrays...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:00<00:00, 155.43it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Filtering 2.83% of samples\n",
-      "Number of samples:\n",
-      "    validation:\n",
-      "      {-100: 40806, 0: 248, 2: 10634, 3: 6830, 1: 1898}\n",
-      "    training:\n",
-      "      {-100: 166305, 2: 41141, 0: 799, 3: 23215, 1: 6620}\n",
-      "    test:\n",
-      "      {1: 0, 2: 0, 3: 0, 0: 0}\n",
-      "Computing normalization statistics...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 465/465 [00:00<00:00, 561.61it/s]\n",
-      "100%|██████████| 465/465 [00:00<00:00, 671.78it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Initializing class weights:\n",
-      "    0.582, 0.07, 0.011, 0.02\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "  x1 = F.pad(x1, [diff // 2, diff - diff // 2])\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 1]: loss 0.0190, f1 0.258\n",
-      "validation: loss 0.0195, f1 0.275\n",
-      "[epoch 2]: loss 0.0131, f1 0.469\n",
-      "validation: loss 0.0163, f1 0.491\n",
-      "[epoch 3]: loss 0.0108, f1 0.622\n",
-      "validation: loss 0.0143, f1 0.549\n",
-      "[epoch 4]: loss 0.0098, f1 0.572\n",
-      "validation: loss 0.0126, f1 0.553\n",
-      "[epoch 5]: loss 0.0087, f1 0.619\n",
-      "validation: loss 0.0119, f1 0.528\n",
-      "[epoch 6]: loss 0.0073, f1 0.706\n",
-      "validation: loss 0.0126, f1 0.538\n",
-      "[epoch 7]: loss 0.0066, f1 0.729\n",
-      "validation: loss 0.0112, f1 0.555\n",
-      "[epoch 8]: loss 0.0064, f1 0.739\n",
-      "validation: loss 0.0104, f1 0.577\n",
-      "[epoch 9]: loss 0.0069, f1 0.712\n",
-      "validation: loss 0.0095, f1 0.621\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m[I 2022-11-23 23:20:02,174]\u001b[0m Trial 0 finished with value: 0.5845697124799093 and parameters: {'losses/ms_tcn/alpha': 0.000466037659013816, 'losses/ms_tcn/focal': True, 'training/temporal_subsampling_size': 0.8179158677217886, 'model/num_f_maps': 35, 'general/len_segment': 512}. Best is trial 0 with value: 0.5845697124799093.\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 10]: loss 0.0080, f1 0.679\n",
-      "validation: loss 0.0136, f1 0.535\n",
-      "Initializing class weights:\n",
-      "    0.582, 0.07, 0.011, 0.02\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "  x1 = F.pad(x1, [diff // 2, diff - diff // 2])\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 1]: loss 1.1031, f1 0.334\n",
-      "validation: loss 1.2366, f1 0.304\n",
-      "[epoch 2]: loss 0.8769, f1 0.557\n",
-      "validation: loss 0.9883, f1 0.636\n",
-      "[epoch 3]: loss 0.7122, f1 0.635\n",
-      "validation: loss 0.9772, f1 0.535\n",
-      "[epoch 4]: loss 0.6906, f1 0.683\n",
-      "validation: loss 0.9260, f1 0.577\n",
-      "[epoch 5]: loss 0.6235, f1 0.664\n",
-      "validation: loss 0.9664, f1 0.494\n",
-      "[epoch 6]: loss 0.5534, f1 0.691\n",
-      "validation: loss 0.9210, f1 0.549\n",
-      "[epoch 7]: loss 0.4894, f1 0.748\n",
-      "validation: loss 0.8069, f1 0.609\n",
-      "[epoch 8]: loss 0.4329, f1 0.796\n",
-      "validation: loss 0.8064, f1 0.674\n",
-      "[epoch 9]: loss 0.4227, f1 0.763\n",
-      "validation: loss 0.8675, f1 0.578\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m[I 2022-11-23 23:20:24,608]\u001b[0m Trial 1 finished with value: 0.6534821192423502 and parameters: {'losses/ms_tcn/alpha': 0.0068731120341918375, 'losses/ms_tcn/focal': False, 'training/temporal_subsampling_size': 0.8000183319502718, 'model/num_f_maps': 56, 'general/len_segment': 512}. Best is trial 1 with value: 0.6534821192423502.\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 10]: loss 0.3624, f1 0.788\n",
-      "validation: loss 0.8828, f1 0.651\n",
-      "Initializing class weights:\n",
-      "    0.582, 0.07, 0.011, 0.02\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "  x1 = F.pad(x1, [diff // 2, diff - diff // 2])\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 1]: loss 1.1213, f1 0.391\n",
-      "validation: loss 1.1405, f1 0.333\n",
-      "[epoch 2]: loss 0.9407, f1 0.534\n",
-      "validation: loss 0.9671, f1 0.530\n",
-      "[epoch 3]: loss 0.7019, f1 0.654\n",
-      "validation: loss 0.8163, f1 0.522\n",
-      "[epoch 4]: loss 0.6742, f1 0.706\n",
-      "validation: loss 0.9383, f1 0.443\n",
-      "[epoch 5]: loss 0.5794, f1 0.721\n",
-      "validation: loss 0.9029, f1 0.460\n",
-      "[epoch 6]: loss 0.5072, f1 0.763\n",
-      "validation: loss 0.9066, f1 0.615\n",
-      "[epoch 7]: loss 0.4877, f1 0.738\n",
-      "validation: loss 0.9254, f1 0.626\n",
-      "[epoch 8]: loss 0.5356, f1 0.752\n",
-      "validation: loss 1.2052, f1 0.511\n",
-      "[epoch 9]: loss 0.4482, f1 0.764\n",
-      "validation: loss 0.6593, f1 0.631\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m[I 2022-11-23 23:20:44,525]\u001b[0m Trial 2 finished with value: 0.6325108607610067 and parameters: {'losses/ms_tcn/alpha': 0.0009675341026784969, 'losses/ms_tcn/focal': False, 'training/temporal_subsampling_size': 0.8648931995468957, 'model/num_f_maps': 80, 'general/len_segment': 512}. Best is trial 1 with value: 0.6534821192423502.\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 10]: loss 0.3666, f1 0.787\n",
-      "validation: loss 0.7669, f1 0.641\n",
-      "Computing input features...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:10<00:00,  1.88it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Computing annotation arrays...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:00<00:00, 156.02it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of samples:\n",
-      "    validation:\n",
-      "      {-100: 41830, 0: 248, 2: 10634, 3: 6830, 1: 1898}\n",
-      "    training:\n",
-      "      {-100: 173985, 2: 41141, 0: 799, 3: 23215, 1: 6620}\n",
-      "    test:\n",
-      "      {1: 0, 2: 0, 3: 0, 0: 0}\n",
-      "Computing normalization statistics...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 240/240 [00:00<00:00, 554.97it/s]\n",
-      "100%|██████████| 240/240 [00:00<00:00, 550.09it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Initializing class weights:\n",
-      "    0.3, 0.036, 0.006, 0.01\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "  x1 = F.pad(x1, [diff // 2, diff - diff // 2])\n",
-      "\u001b[32m[I 2022-11-23 23:20:59,454]\u001b[0m Trial 3 pruned. \u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Number of samples:\n",
-      "    validation:\n",
-      "      {-100: 40806, 0: 248, 2: 10634, 3: 6830, 1: 1898}\n",
-      "    training:\n",
-      "      {-100: 166305, 2: 41141, 0: 799, 3: 23215, 1: 6620}\n",
-      "    test:\n",
-      "      {1: 0, 2: 0, 3: 0, 0: 0}\n",
-      "Computing normalization statistics...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 465/465 [00:00<00:00, 563.50it/s]\n",
-      "100%|██████████| 465/465 [00:00<00:00, 516.04it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Initializing class weights:\n",
-      "    0.582, 0.07, 0.011, 0.02\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning: __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "  x1 = F.pad(x1, [diff // 2, diff - diff // 2])\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 1]: loss 0.0157, f1 0.384\n",
-      "validation: loss 0.0171, f1 0.341\n",
-      "[epoch 2]: loss 0.0099, f1 0.625\n",
-      "validation: loss 0.0146, f1 0.519\n",
-      "[epoch 3]: loss 0.0085, f1 0.637\n",
-      "validation: loss 0.0128, f1 0.509\n",
-      "[epoch 4]: loss 0.0066, f1 0.678\n",
-      "validation: loss 0.0101, f1 0.551\n",
-      "[epoch 5]: loss 0.0057, f1 0.744\n",
-      "validation: loss 0.0121, f1 0.516\n",
-      "[epoch 6]: loss 0.0058, f1 0.759\n",
-      "validation: loss 0.0139, f1 0.554\n",
-      "[epoch 7]: loss 0.0056, f1 0.736\n",
-      "validation: loss 0.0111, f1 0.638\n",
-      "[epoch 8]: loss 0.0049, f1 0.748\n",
-      "validation: loss 0.0106, f1 0.665\n",
-      "[epoch 9]: loss 0.0042, f1 0.766\n",
-      "validation: loss 0.0082, f1 0.707\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[32m[I 2022-11-23 23:21:21,955]\u001b[0m Trial 4 finished with value: 0.6697884798049927 and parameters: {'losses/ms_tcn/alpha': 3.976687373793473e-05, 'losses/ms_tcn/focal': True, 'training/temporal_subsampling_size': 0.9172326638039339, 'model/num_f_maps': 88, 'general/len_segment': 512}. Best is trial 4 with value: 0.6697884798049927.\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 10]: loss 0.0046, f1 0.765\n",
-      "validation: loss 0.0128, f1 0.552\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33m[W 2022-11-23 23:21:23,085]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n",
-      "\u001b[33m[W 2022-11-23 23:21:23,153]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n",
-      "\u001b[33m[W 2022-11-23 23:21:23,162]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n",
-      "\u001b[33m[W 2022-11-23 23:21:23,169]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n",
-      "\u001b[33m[W 2022-11-23 23:21:23,216]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n",
-      "\u001b[33m[W 2022-11-23 23:21:23,564]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n",
-      "\u001b[33m[W 2022-11-23 23:21:23,588]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n",
-      "\u001b[33m[W 2022-11-23 23:21:23,608]\u001b[0m Param general/len_segment unique value length is less than 2.\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "best parameters: {'losses/ms_tcn/alpha': 3.976687373793473e-05, 'losses/ms_tcn/focal': True, 'training/temporal_subsampling_size': 0.9172326638039339, 'model/num_f_maps': 88, 'general/len_segment': 512}\n",
-      "\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'losses/ms_tcn/alpha': 3.976687373793473e-05,\n",
-       " 'losses/ms_tcn/focal': True,\n",
-       " 'training/temporal_subsampling_size': 0.9172326638039339,\n",
-       " 'model/num_f_maps': 88,\n",
-       " 'general/len_segment': 512}"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "project.run_default_hyperparameter_search(\n",
     "    \"test_search\",\n",
@@ -650,7 +280,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Training models"
+    "### Training models"
    ]
   },
   {
@@ -662,133 +292,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TRAINING test_best\n",
-      "Computing input features...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:13<00:00,  1.49it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Computing annotation arrays...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:00<00:00, 364.94it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Filtering 4.34% of samples\n",
-      "Number of samples:\n",
-      "    validation:\n",
-      "      {-100: 161290, 0: 707, 2: 42341, 3: 27320, 1: 7446}\n",
-      "    training:\n",
-      "      {-100: 649094, 2: 163336, 0: 2374, 3: 92604, 1: 26480}\n",
-      "    test:\n",
-      "      {1: 0, 2: 0, 3: 0, 0: 0}\n",
-      "Computing normalization statistics...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 1824/1824 [00:02<00:00, 693.55it/s]\n",
-      "100%|██████████| 1824/1824 [00:02<00:00, 658.31it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Initializing class weights:\n",
-      "    0.768, 0.069, 0.011, 0.02\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning:\n",
-      "\n",
-      "__floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[epoch 1]: loss 0.0104, f1 0.531, precision 0.498\n",
-      "validation: loss 0.0134, f1 0.516, precision 0.579\n",
-      "[epoch 2]: loss 0.0055, f1 0.699, precision 0.649\n",
-      "validation: loss 0.0128, f1 0.547, precision 0.521\n",
-      "[epoch 3]: loss 0.0044, f1 0.752, precision 0.704\n",
-      "validation: loss 0.0104, f1 0.689, precision 0.698\n",
-      "[epoch 4]: loss 0.0035, f1 0.765, precision 0.715\n",
-      "validation: loss 0.0105, f1 0.620, precision 0.625\n",
-      "[epoch 5]: loss 0.0030, f1 0.816, precision 0.777\n",
-      "validation: loss 0.0115, f1 0.618, precision 0.588\n",
-      "[epoch 6]: loss 0.0031, f1 0.781, precision 0.726\n",
-      "validation: loss 0.0120, f1 0.618, precision 0.588\n",
-      "[epoch 7]: loss 0.0026, f1 0.785, precision 0.728\n",
-      "validation: loss 0.0110, f1 0.665, precision 0.624\n",
-      "[epoch 8]: loss 0.0018, f1 0.844, precision 0.794\n",
-      "validation: loss 0.0082, f1 0.718, precision 0.687\n",
-      "[epoch 9]: loss 0.0019, f1 0.827, precision 0.774\n",
-      "validation: loss 0.0100, f1 0.695, precision 0.671\n",
-      "[epoch 10]: loss 0.0013, f1 0.891, precision 0.850\n",
-      "validation: loss 0.0129, f1 0.709, precision 0.690\n",
-      "[epoch 11]: loss 0.0015, f1 0.888, precision 0.851\n",
-      "validation: loss 0.0143, f1 0.668, precision 0.638\n",
-      "[epoch 12]: loss 0.0014, f1 0.891, precision 0.855\n",
-      "validation: loss 0.0116, f1 0.721, precision 0.696\n",
-      "[epoch 13]: loss 0.0012, f1 0.914, precision 0.886\n",
-      "validation: loss 0.0121, f1 0.618, precision 0.594\n",
-      "[epoch 14]: loss 0.0013, f1 0.879, precision 0.835\n",
-      "validation: loss 0.0104, f1 0.737, precision 0.715\n",
-      "[epoch 15]: loss 0.0011, f1 0.893, precision 0.851\n",
-      "validation: loss 0.0088, f1 0.735, precision 0.701\n",
-      "\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "<dlc2action.task.task_dispatcher.TaskDispatcher at 0x7f16666345b0>"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "project.run_episode(\n",
     "    \"test_best\",\n",
@@ -801,7 +307,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Evaluation"
+    "### Evaluation"
    ]
   },
   {
@@ -813,20 +319,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAHHCAYAAABXx+fLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAA9hAAAPYQGoP6dpAABdk0lEQVR4nO3dd3yT1f4H8E+a7tK9C4WWTWkZFmSpwAUpiChORBFkXS4XZCkC1wuKA1AvojhAuLJ+LhRFQZAhAlf2qCCzrJYhdNG92+T5/XFImtDdJnmSPJ/365VXDk+fPPkmKe2353zPOSpJkiQQERERKYiD3AEQERERWRoTICIiIlIcJkBERESkOEyAiIiISHGYABEREZHiMAEiIiIixWECRERERIrDBIiIiIgUhwkQERERKQ4TICKyOJVKhddff73Oj0tKSoJKpcKaNWtMHlNd9OnTB3369KnXY1944QVERESYNB4iqjsmQEQmsmbNGqhUKqNbUFAQ+vbti19++cVsz1tQUIDXX38de/bsMdtz2JqzZ8/i9ddfR1JSktyhEJGVcpQ7ACJ788YbbyAyMhKSJCElJQVr1qzBQw89hM2bN+Phhx82+fMVFBRg/vz5AFDvXgl7c/bsWcyfPx99+vQxS2/Ljh076v3YlStXQqvVmjAaIqoPJkBEJjZo0CB06dJF/++xY8ciODgYX3/9tVkSIGoYSZJQVFQENze3Wj/G2dm53s/n5ORU78dau6KiIjg7O8PBgYMLZP34XUpkZj4+PnBzc4Ojo/HfG1qtFh988AHat28PV1dXBAcHY8KECcjMzDQ679ixY4iLi0NAQADc3NwQGRmJMWPGABA1MYGBgQCA+fPn64feqquv0Q3V7du3D1OmTEFgYCB8fHwwYcIElJSUICsrCyNHjoSvry98fX3xyiuvQJIko2vk5+fjpZdeQnh4OFxcXNCmTRv85z//qXBecXExpk+fjsDAQHh6euKRRx7BjRs3Ko3rr7/+wpgxYxAcHAwXFxe0b98eq1atqtV7fPfre+qppwAAffv21b8nuiHCiIgIPPzww9i+fTu6dOkCNzc3fPbZZwCA1atX429/+xuCgoLg4uKCqKgoLFu2rMJz3F0DtGfPHqhUKnz77bd4++230aRJE7i6uqJfv364dOmS0WPvrgHS1TX95z//wYoVK9CiRQu4uLiga9euOHr0aIXn/u677xAVFQVXV1dER0dj48aNdaor+uWXX9C7d294enrCy8sLXbt2xVdffaX/ekREBF544YVav+ZvvvkG//73v9G4cWO4u7sjPj4eKpUKa9eurXCN7du3Q6VS4eeff9YfM9XnTlRX7AEiMrHs7Gykp6dDkiSkpqbio48+Ql5eHkaMGGF03oQJE7BmzRqMHj0aU6ZMQWJiIj7++GP88ccf2L9/P5ycnJCamooBAwYgMDAQs2fPho+PD5KSkvDDDz8AAAIDA7Fs2TJMnDgRjz32GB5//HEAQIcOHWqM88UXX0RISAjmz5+PQ4cOYcWKFfDx8cGBAwfQtGlTLFiwAFu3bsV7772H6OhojBw5EoDoMXnkkUewe/dujB07Fp06dcL27dsxc+ZM/PXXX1iyZIn+OcaNG4cvvvgCzz77LHr27InffvsNgwcPrhBLSkoKunfvDpVKhcmTJyMwMBC//PILxo4di5ycHEybNq3W7/8DDzyAKVOmYOnSpfjXv/6Fdu3aAYD+HgASEhIwfPhwTJgwAePHj0ebNm0AAMuWLUP79u3xyCOPwNHREZs3b8Y///lPaLVaTJo0qcbnXrRoERwcHPDyyy8jOzsb7777Lp577jkcPny4xsd+9dVXyM3NxYQJE6BSqfDuu+/i8ccfx5UrV/S9Rlu2bMGwYcMQExODhQsXIjMzE2PHjkXjxo1r9d6sWbMGY8aMQfv27TFnzhz4+Pjgjz/+wLZt2/Dss8/W6hp3e/PNN+Hs7IyXX34ZxcXFiIqKQvPmzfHtt99i1KhRRueuX78evr6+iIuLA2Daz52oziQiMonVq1dLACrcXFxcpDVr1hid+/vvv0sApC+//NLo+LZt24yOb9y4UQIgHT16tMrnTUtLkwBIr732Wp3ijIuLk7Rarf54jx49JJVKJf3jH//QHysrK5OaNGki9e7dW3/sxx9/lABIb731ltF1n3zySUmlUkmXLl2SJEmSTpw4IQGQ/vnPfxqd9+yzz1aId+zYsVJoaKiUnp5udO4zzzwjeXt7SwUFBZIkSVJiYqIEQFq9enW1r/G7776TAEi7d++u8LVmzZpJAKRt27ZV+JrueQzFxcVJzZs3NzrWu3dvo/dk9+7dEgCpXbt2UnFxsf74hx9+KAGQTp06pT82atQoqVmzZvp/616Tv7+/lJGRoT/+008/SQCkzZs364/FxMRITZo0kXJzc/XH9uzZIwEwumZlsrKyJE9PT6lbt25SYWGh0dcMvw+aNWsmjRo1qsLjq3rNzZs3r/C+zZkzR3JycjJ6PcXFxZKPj480ZswY/bHafu5E5sAhMCIT++STT7Bz507s3LkTX3zxBfr27Ytx48bpe20AMYzh7e2NBx98EOnp6fpbbGwsGjVqhN27dwMQw2cA8PPPP6O0tNSkcY4dOxYqlUr/727dukGSJIwdO1Z/TK1Wo0uXLrhy5Yr+2NatW6FWqzFlyhSj67300kuQJEk/423r1q0AUOG8u/+qlyQJ33//PYYMGQJJkozej7i4OGRnZyM+Pt4kr1knMjJS3wthyLAOSNeT17t3b1y5cgXZ2dk1Xnf06NFG9UH3338/ABi9f1UZNmwYfH19q3zszZs3cerUKYwcORKNGjXSn9e7d2/ExMTUeP2dO3ciNzcXs2fPhqurq9HXDL8P6mrUqFEV6qeGDRuG0tJSo+/5HTt2ICsrC8OGDQMgz+dOZIhDYEQmdu+99xoVQQ8fPhydO3fG5MmT8fDDD8PZ2RkXL15EdnY2goKCKr1GamoqAPHL7YknnsD8+fOxZMkS9OnTB0OHDsWzzz4LFxeXBsXZtGlTo397e3sDAMLDwyscN6xLunr1KsLCwuDp6Wl0nm6I6erVq/p7BwcHtGjRwug83XCTTlpaGrKysrBixQqsWLGi0lh174epREZGVnp8//79eO2113Dw4EEUFBQYfS07O1v/HlXl7vdUl9DcXddVn8fq3teWLVtWeGzLli1rTBYuX74MAIiOjq4xlrqo7L3s2LEj2rZti/Xr1+sT6vXr1yMgIAB/+9vfAMjzuRMZYgJEZGYODg7o27cvPvzwQ1y8eBHt27eHVqtFUFAQvvzyy0ofoytsVqlU2LBhAw4dOoTNmzdj+/btGDNmDBYvXoxDhw4Z9QTUlVqtrvVx6a7iZlPSTQkfMWJEhZoRndrUNNVFZTO+Ll++jH79+qFt27Z4//33ER4eDmdnZ2zduhVLliyp1dT1qt7T2rx/DXmsKVXVG6TRaCqNsarZc8OGDcPbb7+N9PR0eHp6YtOmTRg+fLh+MoAcnzuRISZARBZQVlYGAMjLywMAtGjRAr/++it69epVq+nX3bt3R/fu3fH222/jq6++wnPPPYdvvvkG48aNa9DwRX00a9YMv/76K3Jzc416gc6fP6//uu5eq9Xi8uXLRr0+CQkJRtfTzRDTaDTo37+/SWKsz3uyefNmFBcXY9OmTUa9MbrhSLnp3te7Z5VVdexuup6406dPV9qLpOPr64usrKwKx69evYrmzZvXMlqRAM2fPx/ff/89goODkZOTg2eeeUb/dXN87kR1wRogIjMrLS3Fjh074OzsrB8mevrpp6HRaPDmm29WOL+srEz/CygzM7NCD0CnTp0AiCnmAODu7g4Alf7SMoeHHnoIGo0GH3/8sdHxJUuWQKVSYdCgQQCgv1+6dKnReR988IHRv9VqNZ544gl8//33OH36dIXnS0tLq3OMHh4eAOr2nuh6Nwzf7+zsbKxevbrOz28OYWFhiI6Oxrp16/SJNADs3bsXp06dqvHxAwYMgKenJxYuXIiioiKjrxm+5hYtWuDQoUMoKSnRH/v5559x/fr1OsXbrl07xMTEYP369Vi/fj1CQ0PxwAMP6L9ujs+dqC7YA0RkYr/88ou+NyQ1NRVfffUVLl68iNmzZ8PLywuAqO2ZMGECFi5ciBMnTmDAgAFwcnLCxYsX8d133+HDDz/Ek08+ibVr1+LTTz/FY489hhYtWiA3NxcrV66El5cXHnroIQBiCCIqKgrr169H69at4efnh+joaJPXeugMGTIEffv2xauvvoqkpCR07NgRO3bswE8//YRp06bpexo6deqE4cOH49NPP0V2djZ69uyJXbt2VdpbsWjRIuzevRvdunXD+PHjERUVhYyMDMTHx+PXX39FRkZGnWLs1KkT1Go13nnnHWRnZ8PFxUW/vk9VBgwYAGdnZwwZMgQTJkxAXl4eVq5ciaCgINy6datub5KZLFiwAI8++ih69eqF0aNHIzMzEx9//DGio6ONkqLKeHl5YcmSJRg3bhy6du2KZ599Fr6+vjh58iQKCgr06/aMGzcOGzZswMCBA/H000/j8uXL+OKLLyrUctXGsGHDMG/ePLi6umLs2LEVFkg09edOVCfyTD4jsj+VTYN3dXWVOnXqJC1btsxoqrHOihUrpNjYWMnNzU3y9PSUYmJipFdeeUW6efOmJEmSFB8fLw0fPlxq2rSp5OLiIgUFBUkPP/ywdOzYMaPrHDhwQIqNjZWcnZ1rnBKvi/PuqfWvvfaaBEBKS0szOj5q1CjJw8PD6Fhubq40ffp0KSwsTHJycpJatWolvffeexVeY2FhoTRlyhTJ399f8vDwkIYMGSJdv3690hhTUlKkSZMmSeHh4ZKTk5MUEhIi9evXT1qxYoX+nNpOg5ckSVq5cqXUvHlzSa1WG02Jb9asmTR48OBKH7Np0yapQ4cOkqurqxQRESG988470qpVqyQAUmJiov68qqaEf/fdd0bXqyzeqqbBv/feexXiqex9+uabb6S2bdtKLi4uUnR0tLRp0ybpiSeekNq2bVvje6J7jT179pTc3NwkLy8v6d5775W+/vpro3MWL14sNW7cWHJxcZF69eolHTt2rNav2dDFixf1/xf27dtX6Tm1+dyJzEElSRausCMiIpPq1KkTAgMDsXPnTrlDIbIZrAEiIrIRpaWl+oJ6nT179uDkyZPcCJeojtgDRERkI5KSktC/f3+MGDECYWFhOH/+PJYvXw5vb2+cPn0a/v7+codIZDNYBE1EZCN8fX0RGxuL//73v0hLS4OHhwcGDx6MRYsWMfkhqiP2ABEREZHisAaIiIiIFIcJEBERESkOa4AqodVqcfPmTXh6elp8mwEiIiKqH0mSkJubi7CwsAoLb96NCVAlbt68WWFHbCIiIrIN169fR5MmTao9hwlQJXQbPF6/fl2/dQERERFZt5ycHISHhxtt1FwVJkCV0A17eXl5MQEiIiKyMbUpX2ERNBERESkOEyAiIiJSHCZAREREpDisAWoAjUaD0tJSucOgOnJycoJarZY7DCIikhEToHqQJAnJycnIysqSOxSqJx8fH4SEhHCdJyIihWICVA+65CcoKAju7u78JWpDJElCQUEBUlNTAQChoaEyR0RERHJgAlRHGo1Gn/xw92Xb5ObmBgBITU1FUFAQh8OIiBSIRdB1pKv5cXd3lzkSagjd58caLiIiZWICVE8c9rJt/PyIiJSNCRAREREpDhMgspikpCSoVCqcOHFC7lCIiEjhmAApSJ8+fTBt2jSTXe+FF17A0KFDTXY9U7DGmIiIyPowASIiIlIQSQIK0gFtmdyRyIsJkEK88MIL2Lt3Lz788EOoVCqoVCokJSXh9OnTGDRoEBo1aoTg4GA8//zzSE9P1z9uw4YNiImJgZubG/z9/dG/f3/k5+fj9ddfx9q1a/HTTz/pr7dnz55axXL+/Hn07NkTrq6uiI6Oxt69e42+LkdMRERK8cuLwHuBwJvOwHtBwLIOwP8NADaOBHbOAg4uAU59DSTuBtLOAYWZImmyNypJsseX1TA5OTnw9vZGdnY2vLy8jL5WVFSExMREREZGwtXVFYD4xigtsHycTu5AbSczZWdnY9CgQYiOjsYbb7whHu/khHbt2mHcuHEYOXIkCgsLMWvWLJSVleG3337DrVu30LRpU7z77rt47LHHkJubi99//x0jR44EAIwdOxY5OTlYvXo1AMDPzw/Ozs5VxpCUlITIyEg0adIEH3zwAaKiovD+++9j/fr1SExMhL+/P7KystC6dWuzx1TZ50hEpARLwoGcG3V7jNoFaBRSzS30zn0w4Cjjj9Tqfn/fjQshmkBpAbCwkeWfd04e4OxRu3O9vb3h7OwMd3d3hISEAADeeustdO7cGQsWLNCft2rVKoSHh+PChQvIy8tDWVkZHn/8cTRr1gwAEBMToz/Xzc0NxcXF+uvV1uTJk/HEE08AAJYtW4Zt27bh888/xyuvvIKPP/5YlpiIiJSgMKM8+XnxElCaD+QlV3K7Vd4uygI0xUD2VXGriatPJYlRJTf3AEAl4zgUEyAFO3nyJHbv3o1GjSpmb5cvX8aAAQPQr18/xMTEIC4uDgMGDMCTTz4JX1/fBj1vjx499G1HR0d06dIF586dkzUmIiIlSDkl7r2bAX4tRDu4Q/WPKSsC8lIqJkaVJU2aEpEwFWUB6eerv+69LwKDljb0FdUfEyATcHIXvTFyPG9D5OXlYciQIXjnnXcqfC00NBRqtRo7d+7EgQMHsGPHDnz00Ud49dVXcfjwYURGRjbsyW0oJiIie5F6JwGqKekx5OgK+DQTt+pIkkh8qutN0t0K0kQvkJyYAJmASlX7oSg5OTs7Q6PR6P99zz334Pvvv0dERAQcHSv/VlCpVOjVqxd69eqFefPmoVmzZti4cSNmzJhR4Xq1dejQITzwwAMAgLKyMhw/fhyTJ0+WNSYiIiVI+VPcB8VUf159qFSAm6+4Bbar/lxNqfyz0DgLTEEiIiJw+PBhJCUlIT09HZMmTUJGRgaGDx+Oo0eP4vLly9i+fTtGjx4NjUaDw4cPY8GCBTh27BiuXbuGH374AWlpaWjXrp3+en/++ScSEhKQnp5e6321PvnkE2zcuBHnz5/HpEmTkJmZiTFjxgCAbDERESlBfXqAzEHtBDi5yRsDEyAFefnll6FWqxEVFYXAwECUlJRg//790Gg0GDBgAGJiYjBt2jT4+PjAwcEBXl5e+N///oeHHnoIrVu3xr///W8sXrwYgwYNAgCMHz8ebdq0QZcuXRAYGIj9+/fXKo5FixZh0aJF6NixI/bt24dNmzYhICAAABAWFiZLTERE9k7SltcAyZ0AWQNOg69EXafBk+3h50hESpN5BVjaQkxp/1ce4GCHRTB1mQbPHiAiIiIF0NX/BEbZZ/JTV0yAyGQWLFiARo0aVXrTDVEREZE8dAlQsBkKoG0Rc0AymX/84x94+umnK/2am5vM1W5ERAqnK4AOYv0PACZAZEJ+fn7w8/OTOwwiIqoEe4CMcQiMiIjIzpUWABmXRJszwAQmQPWk1WrlDoEagJ8fESlJ2lkxDd49EPAIljsa68AhsDpydnaGg4MDbt68icDAQDg7O0NV2y3ZSXaSJKGkpARpaWlwcHCodvd6IiJ7oV//J0as2ExMgOrMwcEBkZGRuHXrFm7evCl3OFRP7u7uaNq0KRwc2AlKRPZPvwUGh7/0mADVg7OzM5o2bYqysjLuO2WD1Go1HB0d2XNHRIqRygLoCpgA1ZNKpYKTkxOcnJzkDoWIiKhKkmQwA4w9QHrs/yciIrJj+SlAQToAlVgFmgQmQERERHZMVwDt3wpwcpc3FmvCBIiIiMiOcfirckyAiIiI7JiuADqIBdBGmAARERHZMf0aQOwBMsIEiIiIFKOsGNj8d+DoMrkjsQxtmVgFGmAP0N04DZ6IiBTjzHogfiXg6AbEjgcc7Py34O2LgKYYcPIAfCPljsa6sAeIiIgU4/gKcV9WWN4zYs8Md4BX8Te+Eb4dRESkCKlngOv7y/9985h8sVhK6p36Hw5/VcQEiIgUpeA2kJ8qdxQkB13vj85fR+WJw5I4Bb5qTICISDFKC4DlHYClLYC/jsgdDVlSaSHw5zrR7jRG3N9UUALEHqCKmAARkWKc+RbIvQmU5AFfPgSknZM7IrKUsxuAoizAuxlw/7/EsZQ/xawwe1WUDWRfFW1ugloREyAiUgzdEIiTB1B4G/hiAJB9Td6YyDKOfybu7xkP+DYH3PwBbWl5D4k9Sj0t7j0bA25+8sZijZgAEZEipJwCbhwU057HHQIC2gE5N4D/GwDkp8kdHZmTrvhZpQY6jwZUKqBxV/E1ex4GS+UCiNViAkREiqDr/WnzCBAUDTy/A/BuCtxOAL4cBBTnyhsfmU/8SnHfZgjgGSbaYboEyI5ngrEAunpMgIjI7pUWAH/+n2jHThD3Xk2AETsA9wDg1nFg/VCgrEi2EMlMSguBk2tFW/fZA0BYF3GvhB4gFkBXjgkQEdm9M98CxdmATwTQvH/58YA2wHO/AM6NgMTfgB+eA7Qa2cIkMzAsfm7+YPlxXQKUdhYoyZclNLOSJPYA1YQJEBHZPd3w1z3jK66GG9YFeOYnQO0MnPsB+Pkf4pcH2Yd43Wc/DnBQlx/3DBM3SQsk/yFPbOaUfQ0ozhE1bwFt5I7GOjEBIiK7Zlj83HlM5edE/g144muRHP3xX2DXvywbI5lH6hng2r47xc+VfPa6OiB7XBBRN/wV0E4k91QREyAismuGxc+NQqo+r93jwMN3pkrvXwQc+I/5YyPzqqz42VCYHc8EM9wDjCrHBIiI7JZh8fM9f6/5/HvGAf0WifbOmcCJNWYLjcystBA4eWfl56o+e30htB3OBNMXQLP+p0pMgIjIbp35rrz4ucWDNZ4OAOj1CtDjZdHeNA44/5PZwiMzOrsBKMoUxc8tBlR+ji4ByrgoCqXtCQuga8YEiIjsluHqv3cXP1dFpQIefBfoNBqQNMCGYUDSXvPFSOZRVfGzIXd/sSo0YF+9QGXFQHqCaHMIrGpMgIjILhkWP3caXbfHqlTAkBVAm0cBTTHw9RDglp3MFEo7BxxcYt8LP6adrb742ZA9DoOlnxPJu6uv2AaDKscEiIjskr4A9hHAM7Tuj3dwFDPDmvUGSnKBL+KA2xdMG6MlacuA3xcAn3UCdswAtk2VOyLz0Re+V1H8bMgeC6ENC6BVKnljsWZMgIjI7pQW1FwAWxtObmKNoJDOQEGa2Dcs5y/TxGhJKX8C/+0G/PYqoCkRx06ute2Eriq1KX42ZI9bYqSwALpWmAARkd2pT/FzVVy9gRHbAL9WQPZV0RNUmGGSMM1OUwLsmQ+s6ALcihdDIkPXAa2HiAUA97wud4Smd+77O8XPTasufjYUeg8AlVg4MD/V7OFZRCqnwNcKEyAisjvx1az8XB8eQWLzVM8wIO0M8NVg698+4dYfwMp7gb2vA9pSoO1Q4J9ngI7PA33fFOec/qa8t8BeGK76XVXxsyEXTyCgrWjby4KIKdwFvlaYABGRXUk9DVw/IApg61r8XB2fCLF5qqsvcOMQ8O0T5cNJ1qSsGPhtLvDfe4GUk4Cbv6hlevqH8lqokI5A+6cBSMCeebKGa1JpZ4Frv9f9s29sR8NgBelA3i3RDoqWNxZrxwSIiOyK4crP9Sl+rk5Qe+DZLYCTO3B5O7BxpHVtnnrzGLAiFvj9LVH0HPUUMOksEP1MxWLYPvNF79j5H+3jFz8AHL9T+N76YcCrDrOfQu1oZ3hd749vc7HJL1WNCRAR2Q3DlZ9jJ5jnOcJ7iN4UByfgzHrglynyb55aVgT8OlsUOqedAdwDgae+A576VgzfVSagLdDhedHePddysZpLWZEo7Abq/tk3NpgJJvdn2VBcALH2mAARkd04u0Gs6OvdrOHFz9VpGQc8tg6ACjj2KbB3vvmeqyY3DgGfdQb2vyMKm6OHi16fqCdrfmzveWK6/6VtYt0cW6Zf+bmWxc+GgjuK9yE/Fci5YZ74LEWXAAWxALpGTICIyG7UZ+Xn+op+BnjoY9HeOx84/JF5n+9upYXAjpeBVb2A9POARzAwbCPwxFeAe0DtruHbHOg8VrR/e9W2ez90Q5+dq1n5uSpObuX1MrY+DJbKAuhaYwJERHbBsPi5ptV/TaXrP0UtDQBsmwL8+aVlnvfaPmB5R+DgYtHr0+F50evTdmjdr/XAvwG1C3D1f0DiLpOHahFp58qLn+v72evWA7LlmWBajfh/ALAHqDasIgH65JNPEBERAVdXV3Tr1g1Hjhyp8tw+ffpApVJVuA0ePFh/jiRJmDdvHkJDQ+Hm5ob+/fvj4sWLlngpRCST4w1c+bm+HpgL3PuiaP/0AnBxq/meqyQf2DYNWP2A2MDTMwwY/rMYjnPzq981vZoAXSaKtq32Aul6f+pa/GxIlwDdsuGC8MwrQFkh4OgK+LWUOxrrJ3sCtH79esyYMQOvvfYa4uPj0bFjR8TFxSE1tfIVqX744QfcunVLfzt9+jTUajWeeuop/Tnvvvsuli5diuXLl+Pw4cPw8PBAXFwcioqKLPWyiMiCSguBP++s/hvbgJWf60OlAgZ+AMQ8K2ZeffskcG2/6Z8naS+wvANw+EMAEtBpjFjXp/XgGh9ao/tmi5ltfx0BLvzc8OtZklHxcwM+e8M9wWwxCQQM6n+i6z4MqESyJ0Dvv/8+xo8fj9GjRyMqKgrLly+Hu7s7Vq1aVen5fn5+CAkJ0d927twJd3d3fQIkSRI++OAD/Pvf/8ajjz6KDh06YN26dbh58yZ+/PFHC74yIrKUs98ZFD/XsQDWFFQOwKNrgJaDxF/gXz9sugUGS/KALZOAtX3EX/he4cBz24BHPwdcfUzzHI2CgXuniPbuuWJYzVacNVz5Oa7+1wmKFj0nRVlAxiWThWdRuvofDn/VjqwJUElJCY4fP47+/fvrjzk4OKB///44ePBgra7x+eef45lnnoGHhwcAIDExEcnJyUbX9Pb2Rrdu3aq8ZnFxMXJycoxuRGQ7jpt45ef6UDsBT28AwnuKX6JfxImEpSGu7AI+jRYzzQCxt9U/T4tZaKbWaybg4iUWTzz7vemvby66wvf6FD8bUjsBIZ1E21bXReIU+LqRNQFKT0+HRqNBcHCw0fHg4GAkJyfX+PgjR47g9OnTGDdunP6Y7nF1uebChQvh7e2tv4WHh9f1pRCRTFLPANf33ymANeHKz/Xh5C5qcoKixWq8/zcAyKv5R1kFxTnA5gnA//UX+4/5RADP/woM+UwkKebg5gf0eEm098yzrgUeq2KK4mdDtr4gIqfA143sQ2AN8fnnnyMmJgb33ntvg64zZ84cZGdn62/Xr183UYREZG5GKz+HyRsLALj5AiO2Az6RQOZl4IuBokeoti5tF70+uv3Muk4CJp4CmvczS7hGuk8TiVD6eeCUhWa0NUR8PVd+rorhgoi2piSvvMeRPUC1I2sCFBAQALVajZSUFKPjKSkpCAkJqfax+fn5+OabbzB27Fij47rH1eWaLi4u8PLyMroRkfWTs/i5Op5hYvNUj2AxpPT1ELFKdXWKsoCfxgBfDgRyrgO+LYBRe8RaQ5ba0sDFC+g1S7T3vA5oSi3zvPVhquJnQ7pC6FvxttEDZij1DABJfM95BModjW2QNQFydnZGbGwsdu0qX3xCq9Vi165d6NGjR7WP/e6771BcXIwRI0YYHY+MjERISIjRNXNycnD48OEar0lEtsWw+Lm5GVd+rg+/lsCIbSKpuLYP2DCs6oTiws/Ap+2BE6sBqIBu04B/nAQielsyYuHeyeKXaFYi8Eflc1GswtnvgcKMhhc/G/JvI5LN0gIg/ZxprmkpXACx7mQfApsxYwZWrlyJtWvX4ty5c5g4cSLy8/MxerQYzB85ciTmzJlT4XGff/45hg4dCn9/f6PjKpUK06ZNw1tvvYVNmzbh1KlTGDlyJMLCwjB06FBLvCQishDD4mdrnPYb0gkYvlnMLrrwM7BprPEMq8IMsaHq10OA3JuAf2tg9O/AwCWAs4c8MTu5A/e/Ktr/e1P0tFij+Aas/FwVBzUQGivatrYgIgug685R7gCGDRuGtLQ0zJs3D8nJyejUqRO2bdumL2K+du0aHByM87SEhATs27cPO3bsqPSar7zyCvLz8/H3v/8dWVlZuO+++7Bt2za4urqa/fUQkWVYU/FzdZo9ADz5LbD+MbFRq5s/EPc+kPATsGWiKJJWOQDdZwB93xDbMsgt9u/AgffEUNyxz4DuU+WOyFjaObFytcrB9Kt+h3UBru4VM8Gs+fvqbiyArjuVJNnqkk/mk5OTA29vb2RnZ7MeiMhK/TIVOLJUbP8wbKPc0dTs5Drgx1GiHda1vNA2oB3w6GqgSTf5YqvM8ZXAz38Xu8lPuSJfj1Rlts8ADi0Rhe/P/GTaa59eD3z/jPiMxle9KYFVkSTgvQDRo/j3eCC0s9wRyacuv79lHwIjIqoro+LnCfLGUlsdRwID3hftm0dFz1Wv2cCEeOtLfgCg0wuiEDs/FThi4Y1eq2NU/GyGz143EyzlJKApMf31zSH3pkh+VGogsJ3c0dgOJkBEZHPObrDe4ufq9JgukqBWDwHjDgH9F4r6IGukdgL6vC7a+98FirJlDUdPV/zsFW664mdDPpFiKQBNielW8zY3XQG0f2vr/X6yRkyAiMjm6Fb/vceEBbCW0mM68OyW8inX1ix6OBAYJbaaOLRE7mgEXfGzuT57lcpgXzAbKYTWF0Cz/qdOmAARkU0xKn42cQEsGXNQA33eEO2D7wMFt+WNJ/28QfHz2JrPry/dzvC2siWGfg8wzgCrEyZARGRTdKv/thliHSs/27t2jwEhnYGSXDEUJqfjJl75uSo22wPEBKhOmAARkc0oLSwvgL3HilZ+tmcqB6Dvm6J95KP67W1mCmVFwMk1om3uz17XA5R6puYVvOWmKRXLAgAcAqsrJkBEZDMMi59bDJA7GuVo9RDQpDtQVgj8vlCeGM79UF783HKgeZ/LqzHQKBSQNEDyCfM+V0PdTgC0pYCzp/h/QbXHBIiIbIa5C2CpcioV8Le3Rfv4ciD7muVjOG7hz143DGbtK0IbFkCrVPLGYmuYAJFFacuAsmK5oyBblHpG7KnF4md5RP4NiOgrpof/7y3LPnf6ebE6szlWfq5KmI3sDJ/CAuh6YwJEFqMpBT6NBlbEWvcu02SdWPwsP10t0B+rgIxLlnteo+LnJpZ5zsY2MhMslVPg640JEFlM5mUxXp12RkxlJaqt0kKxlQTA4mc5Ne0FtBwkamP2zrfMcxqu/GzJz143BHY7wXoWgayMrgeIM8DqjgkQWUx6Qnk7wcT795B9O7tBLMbn3ZTFz3LT9QL9+SWQdtb8z3fuB6DwtmWKnw25BwA+EaJ967jlnrcuCjPFhrUAN0GtDyZAZDG3L5S3EzaJDfyIakNf/Dyexc9yC4sF2j0OQAL2vGb+57N08bMha18QUbcAondTwNVb3lhsERMgshjDBCj7avnsBaLqpJ0tL37uNFruaAi4szq0SvTM3frDfM+TnmD54mdD1r4gIoe/GoYJEFlMxp0ESLdZX8Im+WIh22Gp1X+p9oLaAzHPivbuueZ7Hl3vT6vBlit+NqTrAbLWqfC6PyI5/FU/TIDIYnQ9QB1fEPesA6KaGK78HDtB3ljIWO/XRK/cxS3A9YOmv75h8bNcn33oPeI++yqQnyZPDNVJZQ9QgzABIosozilfQr/HDAAqUViYc0PWsMjKnfuexc/Wyr8V0OkF0TZHL9C5jXeKn5tYtvjZkKs34N9GtK2tDkjSGmyCyh6gemECRBah6/3xCBY/OJt0F/9O2CxfTGT9dEMgnbnys1V6YC7g4AQk7gISd5v22sc/E/dyf/aNrXRBxKyrQEkeoHYG/FvLHY1tYgJEFqFLgHT/Uds8Ku45DEZVSTsLXPudKz9bM59m5cNTu/9tupmdhsXP94w1zTXrK1RXCG1lPUC6+p/AKEDtJG8stooJEFmEPgG6053c9k4ClPibGB4juhuLn23D/f8SExuuHwAubTPNNXWrfstV/GzIsAfImpbuYAF0wzEBIou4uwfIvw3g10rsYnxpu3xxkXUyKoDlys9WzTMU6DpZtE3RC1RWBJxYI9rW8NmHdBK9kHnJQO5fckdTjgXQDccEiCzi7gRIpeIwGFXNaOXnOLmjoZrcNwtwbgTcigfOb2zYtYyKnweZJr6GcHIX0/4B6xoGYw9QwzEBIrOTJLGfDmBcrNfmEXF/cQs3RyVjLH62Le4BQPfpor17HqDV1P9a8Vb42VvbekClhUDGRdFmD1D9MQEis8tLFrMVVA6Ab/Py4+E9xQ/Ooiyx0i8RAKSdY/GzLeoxA3D1EZsdn1lfv2ukJwBJe6yj+NmQLgG6ZSU9QGlnxTR4N3+gUYjc0dguJkBkdrrhL59IwNGl/LiDWhS4AlwVmsrpen9Y/GxbXH2AnjNFe89r9evVtabiZ0NhBjPBrKEQ2rD+R6WSNxZbxgSIzO7u+h9Dre8MgyX8ZB0/WEheLH62bd2mAO6BQMYl4OS6uj22rNi6ip8NBceI9XYKM4DMK3JHU17/w+GvhmECRGZXXQLUYgCgdgGyEoHU05aNi6zP2e9Z/GzLnBsB980R7f+9IZKa2jr3g/wrP1dF7SxmgwHWUQjNAmjTYAJEZldZAbSOswfQvL9ocxiMrGX1X6q/Lv8APMOA7GtA/H9r/zij4mdH88TWEKFWtDM8p8CbBhMgMrvqeoAATocnQV/87MDiZ1vm5Abc/2/R/v0toLSg5sfcvlBe/Gytn721bImRlwLkpwJQlU/Pp/phAkRmpS0DMi+Ltm4V6LvpCqFvHgVyb1omLrI+8Vz52W7cMxbwiRAzQI9+WvP5ulW/Wz0EeIebNbR6088Ei2/YNP+G0vX++LUUaxRR/TEBIrPKShJJkKNb1b/UPEOBxt1Em5ujKpNR8fMEeWOhhlM7A71fE+19i4Di3KrPLSsGTq4RbWv+7APaAk4eYkkP3bC+HPQF0Kz/aTAmQGRW+uGvVqJ7uyocBlO2s9+LGTZe4Sx+thcdRohh78LbwKEPqj7v/EagIN06i58NOaiB0HtEW84FEXU9QEGs/2kwJkBkVunVFEAb0q0KnbhL/IVFyqIrgL2Hxc92w8ER6DNftA/+RyS4ldGv+j3WOoufDemGweScCcYp8KbDBIjMStcD5FdDAhQYBfi2ADQl3BxVadLOAVf/d6cA1opW/6WGa/+0mKpdnAMcWFzx67cvAEm7beezD5N5Jpi2DEg9I9ocAms4JkBkVhk1zADTUanKe4EucDq8orD42X6pHIC+b4r24Q/vzF4yYAvFz4Z0M8GST4g/1iwt4xKgKRbFz4bbClH9MAEis9L1AAVUMQPMkK4O6MLP4i8dsn+Gxc/3WNnqv2QabR4RQ0el+aIgWsew+NlWPnvfFmLLD01xeU+MJekXQIyuvqaSaodvIZlNST6Qc0O0a+oBAoCmvQA3P1ErcG2/eWMj62BY/GzNBbBUfyoV8Le3RPvop0DOX6JtWPzcapB88dWFSiXvMFgKC6BNigkQmU3GRXHv5i8Sm5o4OIpNEAGuCq0ULH5WhuYPAk3vFz0nv78tjtlS8bMhXSG0HDPBUjkF3qSYAJHZ1LQCdGUMp8Nzc1T7ln7eoPjZSlf/JdMw7AWKXwlc3mFbxc+GdD1At2SYCcYZYKbFBIjMpj4JUIsBYhG1zMtA+jnzxEXWQdcD0PphMQxC9q3ZA6InSFsGrH9cHLOV4mdDuh6glFNAaaHlnrc4RywsC3ATVFNhAkRmo0+AalEArePiCUT2E+3zXBTRbrH4WZl0vUCl+eLeFj97ryaARzAgacRsMEtJPS3uPcMAd3/LPa89YwJEZlOfHiCAq0IrwbkfWPysRI3vLV/uwrOx7RQ/GzIqhLbgMFgKd4A3OSZAZBaSVL5fTp0ToCHi/q/DYjNFsj/HPxP3LH5WngGLRUH0gMW2VfxsKEyGneH1U+A5/GUyTIDILArSgaIs0fZrWbfHeoaV/4Dh5qj2h8XPyubXEhj9PyB6mNyR1F9jGRKgVPYAmRwTIDIL3fCXd1PAya3uj+eq0PZLv/rvYBY/k23SDYGlJ4jiZHOTJPYAmQMTIDKL+hRAG9LVAV35VSyoSPbBsPg5doK8sRDVl0eQ+OMOEnAr3vzPl3MdKM4WQ4YBbc3/fErBBIjMor4F0DpB0YBPpPiFeXmH6eIieZ36Gii8zeJnsn2W3BleVwAd0BZwdDH/8ykFEyAyi9pugloVbo5qfyQJOHhnR/B7J7P4mWybJbfE4PCXeTABIrNIr+cMMENGm6NqGh4TyevydiDtDODcCIi1wfVfiAxZcksMFkCbBxMgMjmtBsi4JNoNSYCa3id2Xi5IB24cNEloJCNd70/nceJzJbJlYbHiPisRKLht3udiD5B5MAEik8u5LjY9VDsD3s3qfx21U/nmqFwV2rYlnxQF7SoHoPtUuaMhajhXH8CvlWibsw6orLh8TTX2AJkWEyAyOV0BtF/Lhtd5cHNU+6Dr/Yl6CvCJkDUUIpOxxHpA6efF/mku3lw2wtSYAJHJNXQGmKGWcYCDE5BxsfyvILItOX8Bp78W7R4vyRsLkSlZYiaY4Q7wKpX5nkeJmACRyekKoP1MkAC5eAGRfxNtDoPZpiMfib9gmz1Q/hczkT2wxEwwFkCbDxMgMrmGToG/G6fD267iXODYctFm7w/Zm5DOoq4t96a4mQMLoM2HCRCZnCmHwIDyBOj6QSAvxTTXJMv4Y5VYwda/NdD6YbmjITItZw8gsL1om2sYjD1A5sMEiEyqrAjIuiraAfXcBuNuXk2A0FgAklgTiGyDtgw4tES0u88QfykT2RvdMJg51gMquF3esxQUbfrrKx1/JJFJZVwGIIkZC+6Bprsuh8Fsz7kfgOyrgHsA0HGk3NEQmUeYGWeC6Xp/fCIBF0/TX1/pmACRSd02WAHalDMWdNPhL+8ESgtMd10yD0kCDvxHtLtOApzc5I2HyFwaG8wEM/VSHfoZYKz/MQsmQGRSpq7/0QnuIBZVLCsUC+qRdbu2T/xFrHYBuv5T7miIzCcoRizVUXgbyEoy7bX1BdCs/zELJkBkUuZKgAw3R+V0eOunW/iw40jAI0jeWIjMydEFCOko2qYeBmMBtHkxASKT0idAJiqANqTfHHUzN0e1ZrcvAAl3arV6zJA3FiJLCNWtB2TCmWCSFkg9LdocAjMPJkBkUubqAQLEQnou3kBBGvDXYdNfn0zj4BIAkpj2HtBW7miIzM8cW2JkXhH1jo6uYlshMj0mQGQyhZkiOQEA/1amv77aCWj1kGhzGMw65acBJ9eINhc+JKXQzwQ7LnpuTEFX/xMYBTg4muaaZIwJEJmMrvfHMwxwbmSe5+B0eOt2bJlYCyo0FmjWW+5oiCwjsB3g6AaU5Jb/HGyoFNb/mJ3sCdAnn3yCiIgIuLq6olu3bjhy5Ei152dlZWHSpEkIDQ2Fi4sLWrduja1bt+q//vrrr0OlUhnd2rZlP7wlmHP4S6flIDHjIv286X7QkGmUFQFHPxHtHi9x40ZSDgdHIPQe0TbVgoip3ALD7GRNgNavX48ZM2bgtddeQ3x8PDp27Ii4uDikpqZWen5JSQkefPBBJCUlYcOGDUhISMDKlSvRuHFjo/Pat2+PW7du6W/79u2zxMtRPF1CYopNUKvi6g1E9BFtDoNZlz+/APJTAe+mQNSTckdDZFmmXhDRcBd4Mg9ZRxbff/99jB8/HqNHjwYALF++HFu2bMGqVaswe/bsCuevWrUKGRkZOHDgAJycnAAAERERFc5zdHRESEiIWWOninSboJpqC4yqtHkEuLJTDIP1mmne56LakbTlU9+7TRX1WkRKEmbCmWAl+XdW1QcTIHOSrQeopKQEx48fR//+/cuDcXBA//79cfDgwUofs2nTJvTo0QOTJk1CcHAwoqOjsWDBAmg0xnOiL168iLCwMDRv3hzPPfccrl27Vm0sxcXFyMnJMbpR3VliCAww2Bz1gCi6Jfld/EUMS7p4AfeMkzsaIsvTzQRL/gPQlDbsWmlnAEhiDS2uo2U+siVA6enp0Gg0CA4ONjoeHByM5OTkSh9z5coVbNiwARqNBlu3bsXcuXOxePFivPXWW/pzunXrhjVr1mDbtm1YtmwZEhMTcf/99yM3N7fKWBYuXAhvb2/9LTw83DQvUkEkreUSIO+mQEgn8ZwXt5j3uah2Dt7Z9uKev4skiEhp/FqKZTrKioC0sw27FgugLUP2Iui60Gq1CAoKwooVKxAbG4thw4bh1VdfxfLly/XnDBo0CE899RQ6dOiAuLg4bN26FVlZWfj222+rvO6cOXOQnZ2tv12/ft0SL8eu5N4Ua1ao1GLjPnPTLYqYwDog2d2KB5L2iELQblPkjoZIHioHICxWtBtaB5TCAmiLkC0BCggIgFqtRkpKitHxlJSUKut3QkND0bp1a6jVav2xdu3aITk5GSUlJZU+xsfHB61bt8alS5eqjMXFxQVeXl5GN6obXe+Pb3PL1H/oN0fdAZQWmv/5qGq62p/2TwPe7DwlBdMVQjd0Jhi3wLAM2RIgZ2dnxMbGYteuXfpjWq0Wu3btQo8ePSp9TK9evXDp0iVoteUrTV24cAGhoaFwdnau9DF5eXm4fPkyQkNDTfsCyMhtCxVA64R0ArzCRa9T4q4aTyczyb4GnF4v2lz4kJROlwDdakAhtCSxB8hSZB0CmzFjBlauXIm1a9fi3LlzmDhxIvLz8/WzwkaOHIk5c+boz584cSIyMjIwdepUXLhwAVu2bMGCBQswadIk/Tkvv/wy9u7di6SkJBw4cACPPfYY1Go1hg8fbvHXpySWmAJviJujWofDSwFJA0T0LV8HhUipdDPBUv4UtUD1kXdL7CyvchCrQJP5yDoNftiwYUhLS8O8efOQnJyMTp06Ydu2bfrC6GvXrsHBoTxHCw8Px/bt2zF9+nR06NABjRs3xtSpUzFr1iz9OTdu3MDw4cNx+/ZtBAYG4r777sOhQ4cQGBho8denJLcTxL25C6ANtXlELLx3YbMoiFbZVEWb7SvKBo6vEO2eL8sbC5E18G4KuAeKLYGSTwJNutX9GroCaP/WgJObaeMjY7LvMDJ58mRMnjy50q/t2bOnwrEePXrg0KFDVV7vm2++MVVoVAeWmgFmKKKPmHGUnwL8dQRo0t1yz01A/H/F0v8B7YCWA+WOhkh+KpWYDn9xq1gPqF4JEIe/LIZ/M1ODaUqAzETRtmQCpHYWW2MAHAazNE0pcPhD0e4xg71vRDqhugUR61kIzQJoy+GPLWqwzERRB+LkITZCtSRujiqPs98BOdfFIm0dRsgdDZH1aNzALTHYA2Q5TICowQyHvyy9AWbLQWL9mbSzQEbVKx2QCUlS+dT3rpMBR1d54yGyJrpC6LRzQEle3R6rKS1fRJE9QObHBIgaTI4CaB03X6DZA6KdwF4gi7i6Vyx+6OgGdJ0odzRE1qVRCODVBIAk/p/Uxe0LgLYUcG4E+DQzS3hkgAkQNZgcBdCGuCq0ZR24s+1FpxcA9wBZQyGySvVdENFw+It1debHt5gaTPYE6E4d0LV9QEG6PDEoRdq5O/uvqYDu0+WOhsg61XdBRBZAWxYTIGowuRMgnwjxA0PSiumnZD4H3xf3bR8F/FvJGwuRtdLVATWkB4jMjwkQNUhxrli5FJAvAQI4DGYJeSnAn/8n2tz2gqhqugQo8zJQmFH7x7EHyLKYAFGDZFwU9x5BgKuPfHHohsEuba//EvRUvaOfAppioPG9QHgvuaMhsl5uvoBvC9G+ebx2jynKEnvrAUBQtFnCorswAaIGSZdxBpih0FjAszFQmg8k/iZvLPaotEBsOwIAPV62/HIHRLamrusB6bbA8AoXCRSZHxMgahBLb4JaFW6Oal4n14kNGn0igHaPyR0NkfULq2MCxOEvy2MCRA2SIXMBtCH9qtB3Nkcl05C05cXP3aeLhSeJqHq6OqCbtZwJxgJoy2MCRA2i6wEKaCNvHAAQ0VcsIJZ3q/Y/dKhmCZtFrZerD9B5jNzRENmG0HvEWj45N4C85JrPZw+Q5TEBonqTJPmnwBtydCnflZyrQpuObtuL2AkiwSSimjk3AgLaiXZN0+ElqbwGKJg9QBbDBIjqLT8FKM4BoCqf8SA3Toc3rb+OANd+BxycgHtflDsaIttS22Gw7KtASa74f+ZvBb3pSsEEiOpN1/vjEyF6X6xBq4cAlRpIPQ1kXpE7Gtun6/2JGQ54NZY3FiJbU9tCaF39T2A7QO1k3pioHBMgqjdrGv7ScfMDmt0v2hwGa5isJODsBtHuPkPWUIhskn4q/DExzFUVXQLE+h/LYgJE9aZPgKysy5bDYKZx6AMxA6z5g0BIR7mjIbI9wR3ErMmCtPJFDiujK4AOYgJkUUyAqN6ssQcIKJ8Of/X3ui1DT+UKM4H4/4o2t70gqh9H1/JeneqGwfQ9QCyAtigmQFRvt61kFei7+TYXS8lLGm6OWl/HV4hVtYOigRYD5I6GyHaFGQyDVaasqPyPSQ6BWRYTIKoXbRmQcVm0rS0BAjgM1hCaEuDIUtHu8RK3vSBqCP1MsCp6gNLOiqFmNz+gUajl4iImQFRPWVcBbSmgdgG8w+WOpiL95qjbgLJieWOxNafXA7k3gUYhQPRwuaMhsm2GPUCVrVCfYrAAIv/YsCwmQFQv+vqfVmK1U2sT1kX8NVWSByTtljsa2yFJwMH/iPa9U6xneQMiWxXUXtQCFecAGZcqfp1bYMjHCn91kS2w1hlgOioHoPUQ0eZ0+NpL3CV+IDu5A10myB0Nke1zcARCOot2ZStCp3IKvGyYAFG9WGsBtKG2ujqgTdWvwUHlDtzp/ek0RtQkEFHDVbcgYgr3AJONyRKg69evY8wY7pSoFNY6Bd5Q5N8AJw8g9y/g1nG5o7F+qaeBy9tF71n3aXJHQ2Q/GlcxEyw/VWwpBBUQ2N7iYSmeyRKgjIwMrF271lSXIytnCwmQoyvQMk60OQxWs4Pvi/u2jwF+VrK3G5E90M0EuxUvZtDq6Hp//FoAzh6Wj0vpHGt74qZN1f8GuXKFGy8pRWkBkHNdtK05AQLEdPhzP4jp8H3fkDsa65V7C/jzC9Hu+bK8sRDZG//WgLOn2PA07Wz5cBcLoOVV6wRo6NChUKlUkKopplBxDp8i6GYyuPkB7gHyxlKTVg+JIZ2UP8XeVj4RckdknY58LJY1CO8JNOkudzRE9kXlAITFAkl7xDCYLgFKZf2PrGo9BBYaGooffvgBWq220lt8fLw54yQrYgvDXzruAUDT+0Sbw2CVK8kHji0TbW57QWQeukJow5lg7AGSV60ToNjYWBw/XnUlaU29Q2Q/0m1gBpghrgpdvROrgaJMwLdF+XtFRKZ190wwrQZIOyPa7AGSR60SoD///BMzZ85Ez549qzynZcuW2L2bK84pQcadHiA/W0mA7qwKnbRXbPJJ5bQa4NAS0e4+HXBQyxsPkb3SFUKn/ClWp8+4JPYBc3IX+xeS5dUqAercuTPatGmDgQMHonnz5rh9+3aFczw8PNC7d2+TB0jWx5aGwADAryUQGCU2R730i9zRWJfzPwKZV0Q9V6cX5I6GyH75RABu/qLWLuXP8uGvwPb8w0MutUqAfHx8kJiYCABISkqCVlvJhiakGLoEKMBKV4GuTOs7vUCsAzJ2cLG47zKR03CJzEmlMlgP6CgLoK1BrWaBPfHEE+jduzdCQ0OhUqnQpUsXqNWVp6ycDm/fCm4DhRmi7ddS3ljqou2jwP5FogdIUwKoneWOSH7XDwA3Dor34t7JckdDZP9Cu4gNmm8eK/85ygJo+dQqAVqxYgUef/xxXLp0CVOmTMH48ePh6elp7tjICum2wPAKF2PXtqLxvYBHsFh1NWkP0GKA3BHJT9f7EzNC7PxOROZl2ANUki/a7AGST63XARo4cCAA4Pjx45g6dSoTIIWytfofHd3mqH/8VwyDKT0ByrgMnNso2j1myBsLkVLoCqHTzgLSnUqSYPYAyabOW2GsXr2ayY+C2WoCBBhsjvoTkHVVzMBQqkMfAJCAlgOBIO5BRGQRnmHipkt+GoVa/2Ky9qzWPUBEgEECZEMF0DqR/cSwXc4N4MMIcczVRwz/NAq9c294Mzjm7i96kexBYQZwYpVo9+C2F0QWFda1fE0yDn/JiwkQ1Ykt9wA5uQF95ottH/JuiWLooixxSz9f/WNVaqBRcO2SJWufTXVsudjPLbgjEPk3uaMhUhbDBIgF0PJiAkS1JmmBjIuibYsJECA2+uz5MiBJIvHJSza43brr33duBWliDaHcm+JWE+dGlSdG+t6kQPnW/ZC0wJGPRLvny2JqLhFZjq4OCGAPkNyYAFGtZV8XdTMOToBPM7mjaRiVCnDzFbfAdtWfqykF8lNrkSzdEj0rJXlilVfdprHWyLMx0H6Y3FEQKY9RAsQeIFkxAaJa0w1/+bUAHBT0naN2Arwai1t1JEkkP5UlRkY9SukAZNw2z8EJ6LdQvC4isix3f6DnTPGzgENg8lLQrzFqKFuu/7EElQpw8RQ3/1ZyR0NE1urBd+WOgIB6TIMn5bLlGWBERESGmABRrelWgWYPEBER2TomQFRrHAIjIiJ7wQSIaqWsGMhKEm0mQEREZOuYAFGtZF4GIAHOnmJTUSIiIlvGBIhqRTf8FdCGi+cREZHtYwJEtcL6HyIisidMgKhW0u/MAPNjAkRERHaACRDVSgZ7gIiIyI4wAaJa4RAYERHZEyZAVKOiLLEZKMAEiIiI7AMTIKrR7YvivlGo2OeKiIjI1jEBohpxCwwiIrI3TICoRqz/ISIie8MEiGrEBIiIiOwNEyCqERMgIiKyN0yAqFqSZJAAtZE3FiIiIlNhAkTVyr0JlOYDKjXgGyl3NERERKbBBIiqpev98Y0E1M7yxkJERGQqTICoWqz/ISIie8QEiKqlS4C4CSoREdkT2ROgTz75BBEREXB1dUW3bt1w5MiRas/PysrCpEmTEBoaChcXF7Ru3Rpbt25t0DWparpNUANYAE1ERHZE1gRo/fr1mDFjBl577TXEx8ejY8eOiIuLQ2pqaqXnl5SU4MEHH0RSUhI2bNiAhIQErFy5Eo0bN673Nal66VwFmoiI7JBKkiRJrifv1q0bunbtio8//hgAoNVqER4ejhdffBGzZ8+ucP7y5cvx3nvv4fz583BycjLJNSuTk5MDb29vZGdnw8vLq56vzvZpSoG33QBJA0y/Dng1kTsiIiKiqtXl97dsPUAlJSU4fvw4+vfvXx6MgwP69++PgwcPVvqYTZs2oUePHpg0aRKCg4MRHR2NBQsWQKPR1PuaAFBcXIycnByjGwFZiSL5cXIHPMPkjoaIiMh0ZEuA0tPTodFoEBwcbHQ8ODgYycnJlT7mypUr2LBhAzQaDbZu3Yq5c+di8eLFeOutt+p9TQBYuHAhvL299bfw8PAGvjr7oC+AbgWoZK8WIyIiMh2b+rWm1WoRFBSEFStWIDY2FsOGDcOrr76K5cuXN+i6c+bMQXZ2tv52/fp1E0Vs226zAJqIiOyUo1xPHBAQALVajZSUFKPjKSkpCAkJqfQxoaGhcHJyglqt1h9r164dkpOTUVJSUq9rAoCLiwtcXFwa8GrsE6fAExGRvZKtB8jZ2RmxsbHYtWuX/phWq8WuXbvQo0ePSh/Tq1cvXLp0CVqtVn/swoULCA0NhbOzc72uSVW7zRlgRERkp2QdApsxYwZWrlyJtWvX4ty5c5g4cSLy8/MxevRoAMDIkSMxZ84c/fkTJ05ERkYGpk6digsXLmDLli1YsGABJk2aVOtrUu1xFWgiIrJXsg2BAcCwYcOQlpaGefPmITk5GZ06dcK2bdv0RczXrl2Dg0N5jhYeHo7t27dj+vTp6NChAxo3boypU6di1qxZtb4m1U5JntgIFQD8W8kbCxERkanJug6QteI6QMCtP4AV9wDuAcDMNLmjISIiqplNrANE1k0//MUZYEREZIeYAFGlWABNRET2jAkQVYoF0EREZM+YAFGlmAAREZE9YwJEFUgSEyAiIrJvTICogoI0oDgbgArwayl3NERERKbHBIgqSL9TAO3TDHB0lTcWIiIic2ACRBVw+IuIiOwdEyCqgJugEhGRvWMCRBVksAeIiIjsHBMgqkDXAxTAVaCJiMhOMQEiI1oNkHFJtNkDRERE9ooJEBnJvgpoSgC1C+AVLnc0RERE5sEEiIzoC6BbAg5qeWMhIiIyFyZAZIRT4ImISAmYAJERJkBERKQETIDIiD4B4gwwIiKyY0yAyMjtO9tgsAeIiIjsGRMg0istBLKviTYTICIismdMgEhPt/6Pqw/gHiBrKERERGbFBIj0DAugVSp5YyEiIjInJkCkxwJoIiJSCiZApMcCaCIiUgomQKTHNYCIiEgpmACRHhMgIiJSCiZABAAouA0U3hZtv1byxkJERGRuTIAIAJBxUdx7NQGcPeSNhYiIyNyYABEAIJ0F0EREpCBMgAhAef2PHxMgIiJSACZABADIYAE0EREpCBMgAsAZYEREpCxMgAiSFrh9pwiaCRARESkBEyBCzg2grBBwcAR8I+WOhoiIyPyYAJF++Mu3hUiCiIiI7B0TIGL9DxERKQ4TIGICREREisMEiJgAERGR4jABovIEqI28cRAREVkKEyCFKysGshJFmz1ARESkFEyAFC7zilgHyLkR0ChE7miIiIgsgwmQwhnW/6hU8sZCRERkKUyAFI4F0EREpERMgBSOBdBERKRETIAU7naCuGcPEBERKQkTIIXjEBgRESkREyAFK8oG8lNE26+VvLEQERFZEhMgBcu4KO49ggFXb3ljISIisiQmQAqmG/4KYAE0EREpDBMgBUu/UwDtx/ofIiJSGCZACpbBAmgiIlIoJkAKxhlgRESkVEyAFEqSmAAREZFyMQFSqLxkoCQPUDkAvs3ljoaIiMiymAAplG4FaJ9IwNFF3liIiIgsjQmQQnH4i4iIlIwJkEIxASIiIiVjAqRQTICIiEjJmAApFBMgIiJSMiZACqQtAzIvi7Y/t8EgIiIFYgKkQJmJIglydAO8GssdDRERkeUxAVIg/fBXK7EOEBERkdLw158Csf6HiIiUjgmQAukSIO4CT0RESsUESIF0u8AHsACaiIgUigmQAqXf2QaDQ2BERKRUVpEAffLJJ4iIiICrqyu6deuGI0eOVHnumjVroFKpjG6urq5G57zwwgsVzhk4cKC5X4ZNKMkDcv8SbSZARESkVI5yB7B+/XrMmDEDy5cvR7du3fDBBx8gLi4OCQkJCAoKqvQxXl5eSEhI0P9bpVJVOGfgwIFYvXq1/t8uLtzxEwAyLol7N3/AzU/eWIiIiOQiew/Q+++/j/Hjx2P06NGIiorC8uXL4e7ujlWrVlX5GJVKhZCQEP0tODi4wjkuLi5G5/j6+przZdgMzgAjIiKSOQEqKSnB8ePH0b9/f/0xBwcH9O/fHwcPHqzycXl5eWjWrBnCw8Px6KOP4syZMxXO2bNnD4KCgtCmTRtMnDgRt2/frvJ6xcXFyMnJMbrZKyZAREREMidA6enp0Gg0FXpwgoODkZycXOlj2rRpg1WrVuGnn37CF198Aa1Wi549e+LGjRv6cwYOHIh169Zh165deOedd7B3714MGjQIGo2m0msuXLgQ3t7e+lt4eLjpXqSVua0rgOYMMCIiUjDZa4DqqkePHujRo4f+3z179kS7du3w2Wef4c033wQAPPPMM/qvx8TEoEOHDmjRogX27NmDfv36VbjmnDlzMGPGDP2/c3Jy7DYJYg8QERGRzD1AAQEBUKvVSElJMTqekpKCkJCQWl3DyckJnTt3xqVLl6o8p3nz5ggICKjyHBcXF3h5eRnd7JEkMQEiIiICZE6AnJ2dERsbi127dumPabVa7Nq1y6iXpzoajQanTp1CaGholefcuHEDt2/frvYcJShIB4qyRNuvpayhEBERyUr2WWAzZszAypUrsXbtWpw7dw4TJ05Efn4+Ro8eDQAYOXIk5syZoz//jTfewI4dO3DlyhXEx8djxIgRuHr1KsaNGwdAFEjPnDkThw4dQlJSEnbt2oVHH30ULVu2RFxcnCyv0Vpc3SvuvZsCTm7yxkJERCQn2WuAhg0bhrS0NMybNw/Jycno1KkTtm3bpi+MvnbtGhwcyvO0zMxMjB8/HsnJyfD19UVsbCwOHDiAqKgoAIBarcaff/6JtWvXIisrC2FhYRgwYADefPNNRa8FVJgB/DJFtNsPkzcWIiIiuakkSZLkDsLa5OTkwNvbG9nZ2XZTD/T9cOD0N0BAW+Dv8ewBIiIi+1OX39+yD4GR+Z35ViQ/KjUwdB2THyIiIiZAdi73FrBlomjf/y+gcVd54yEiIrIGTIDsmCQBm8eL+p+QzsAD/5Y7IiIiIuvABMiO/bEKuLgFUDsDj60T90RERMQEyG5lJQHbp4l237eAoGg5oyEiIrIuTIDskKQFfnwBKMkDmt4H9JhR40OIiIgUhQmQHTq8VCx66OQBPLoGcFDLHREREZF1YQJkZ9LPA7vuLJw94D+AXwt54yEiIrJGTIDsiLYM+HEUUFYEtIgDYifIHREREZF1YgJkR/YtAv46Arj6AI98DqhUckdERERknZgA2YlbfwB754v2oI8Br8byxkNERGTNmADZgbJi4MeRYgis3eNAzLNyR0RERGTdmADZgd3zgNTTgEcQMHg5h76IiIhqwgTIxl3bDxx4T7QfXgF4BMobDxERkS1gAmTDSvLErC9IQMdRQNtH5Y6IiIjINjABsmE7XwEyLwNe4cDAD+WOhoiIyHYwAbJRl3cAx5aJ9qOrAVdveeMhIiKyJUyAbFBhJvDTGNHuOhlo3k/eeIiIiGwNEyAbtG0KkPsX4NcKePAduaMhIiKyPUyAbMy5H4A/vwBUDsBj6wAnd7kjIiIisj1MgGxIXgrw8539vXrNApp0lzceIiIiW8UEyEZIkkh+CtKB4A5A79fkjoiIiMh2MQGyESfXAQk/AQ5OwGP/Bzi6yB0RERGR7WICZAOyr4nCZwDoM1/0ABEREVH9MQGycpIW2DQWKM4RNT+9ZsodERERke1jAmTlji4DrvwKOLoBQ9cBDo5yR0RERGT7mABZsdsXgZ13enwefBfwbyVvPERERPaCCZCV0mrERqdlhUBkP6DrP+WOiIiIyH4wAbJSB94DbhwEXLzEXl8qflJEREQmw1+rVijlT2D3PNEeuBTwDpc3HiIiInvDBMjKaEqAjSMBbSnQ5hGg40i5IyIiIrI/TICszJ75QMpJwD0AeHgFoFLJHREREZH9YQJkRW4cAvYvEu3By4FGwfLGQ0REZK+YAFmJ0gIx60vSAjHPAVFPyB0RERGR/WICZCV+nQ3cvgB4NgYGfSR3NERERPaNCZAVuLILOHIn6Xnkc8DNV954iIiI7B0TIJkVZQM/jRbt2H8ALePkjYeIiEgJmADJbPs0IOc64NscGPCe3NEQEREpAxMgGSVsAk6sAaAChq4FnBvJHREREZEyMAGSSX4asHm8aPd8GWh6n7zxEBERKQkTIBlIErBlIpCfCgS2B/q+IXdEREREysIESAanvgLOfQ84OAKP/R/g6Cp3RERERMrCBMjCcv4Cfpks2g/MA0I7yxsPERGREjEBsiBJAjaPA4qygLCuwP1z5I6IiIhImZgAWdDxFcClbWLI67F1YgiMiIiILI8JkAVpSwG1M9BvIRDQVu5oiIiIlIt9EBZ072Sg5UCx6CERERHJhwmQhfm1lDsCIiIi4hAYERERKQ4TICIiIlIcJkBERESkOEyAiIiISHGYABEREZHiMAEiIiIixWECRERERIrDBIiIiIgUhwkQERERKQ4TICIiIlIcJkBERESkOEyAiIiISHGYABEREZHicDf4SkiSBADIycmRORIiIiKqLd3vbd3v8eowAapEbm4uACA8PFzmSIiIiKiucnNz4e3tXe05Kqk2aZLCaLVa3Lx5E56enlCpVHKHY1I5OTkIDw/H9evX4eXlJXc4Fqf01w/wPeDrV/brB/ge2PPrlyQJubm5CAsLg4ND9VU+7AGqhIODA5o0aSJ3GGbl5eVld9/4daH01w/wPeDrV/brB/ge2Ovrr6nnR4dF0ERERKQ4TICIiIhIcZgAKYyLiwtee+01uLi4yB2KLJT++gG+B3z9yn79AN8Dpb9+HRZBExERkeKwB4iIiIgUhwkQERERKQ4TICIiIlIcJkBERESkOEyAFGDhwoXo2rUrPD09ERQUhKFDhyIhIUHusGS1aNEiqFQqTJs2Te5QLOavv/7CiBEj4O/vDzc3N8TExODYsWNyh2UxGo0Gc+fORWRkJNzc3NCiRQu8+eabtdozyBb973//w5AhQxAWFgaVSoUff/zR6OuSJGHevHkIDQ2Fm5sb+vfvj4sXL8oTrJlU9x6UlpZi1qxZiImJgYeHB8LCwjBy5EjcvHlTvoBNrKbvAUP/+Mc/oFKp8MEHH1gsPrkxAVKAvXv3YtKkSTh06BB27tyJ0tJSDBgwAPn5+XKHJoujR4/is88+Q4cOHeQOxWIyMzPRq1cvODk54ZdffsHZs2exePFi+Pr6yh2axbzzzjtYtmwZPv74Y5w7dw7vvPMO3n33XXz00Udyh2YW+fn56NixIz755JNKv/7uu+9i6dKlWL58OQ4fPgwPDw/ExcWhqKjIwpGaT3XvQUFBAeLj4zF37lzEx8fjhx9+QEJCAh555BEZIjWPmr4HdDZu3IhDhw4hLCzMQpFZCYkUJzU1VQIg7d27V+5QLC43N1dq1aqVtHPnTql3797S1KlT5Q7JImbNmiXdd999cochq8GDB0tjxowxOvb4449Lzz33nEwRWQ4AaePGjfp/a7VaKSQkRHrvvff0x7KysiQXFxfp66+/liFC87v7PajMkSNHJADS1atXLROUBVX1+m/cuCE1btxYOn36tNSsWTNpyZIlFo9NLuwBUqDs7GwAgJ+fn8yRWN6kSZMwePBg9O/fX+5QLGrTpk3o0qULnnrqKQQFBaFz585YuXKl3GFZVM+ePbFr1y5cuHABAHDy5Ens27cPgwYNkjkyy0tMTERycrLR/wNvb29069YNBw8elDEyeWVnZ0OlUsHHx0fuUCxCq9Xi+eefx8yZM9G+fXu5w7E4boaqMFqtFtOmTUOvXr0QHR0tdzgW9c033yA+Ph5Hjx6VOxSLu3LlCpYtW4YZM2bgX//6F44ePYopU6bA2dkZo0aNkjs8i5g9ezZycnLQtm1bqNVqaDQavP3223juuefkDs3ikpOTAQDBwcFGx4ODg/VfU5qioiLMmjULw4cPt8sNQivzzjvvwNHREVOmTJE7FFkwAVKYSZMm4fTp09i3b5/coVjU9evXMXXqVOzcuROurq5yh2NxWq0WXbp0wYIFCwAAnTt3xunTp7F8+XLFJEDffvstvvzyS3z11Vdo3749Tpw4gWnTpiEsLEwx7wFVrrS0FE8//TQkScKyZcvkDscijh8/jg8//BDx8fFQqVRyhyMLDoEpyOTJk/Hzzz9j9+7daNKkidzhWNTx48eRmpqKe+65B46OjnB0dMTevXuxdOlSODo6QqPRyB2iWYWGhiIqKsroWLt27XDt2jWZIrK8mTNnYvbs2XjmmWcQExOD559/HtOnT8fChQvlDs3iQkJCAAApKSlGx1NSUvRfUwpd8nP16lXs3LlTMb0/v//+O1JTU9G0aVP9z8SrV6/ipZdeQkREhNzhWQR7gBRAkiS8+OKL2LhxI/bs2YPIyEi5Q7K4fv364dSpU0bHRo8ejbZt22LWrFlQq9UyRWYZvXr1qrD0wYULF9CsWTOZIrK8goICODgY/82nVquh1Wplikg+kZGRCAkJwa5du9CpUycAQE5ODg4fPoyJEyfKG5wF6ZKfixcvYvfu3fD395c7JIt5/vnnK9RCxsXF4fnnn8fo0aNlisqymAApwKRJk/DVV1/hp59+gqenp36M39vbG25ubjJHZxmenp4Vap48PDzg7++viFqo6dOno2fPnliwYAGefvppHDlyBCtWrMCKFSvkDs1ihgwZgrfffhtNmzZF+/bt8ccff+D999/HmDFj5A7NLPLy8nDp0iX9vxMTE3HixAn4+fmhadOmmDZtGt566y20atUKkZGRmDt3LsLCwjB06FD5gjax6t6D0NBQPPnkk4iPj8fPP/8MjUaj/9no5+cHZ2dnucI2mZq+B+5O+JycnBASEoI2bdpYOlR5yD0NjcwPQKW31atXyx2arJQ0DV6SJGnz5s1SdHS05OLiIrVt21ZasWKF3CFZVE5OjjR16lSpadOmkqurq9S8eXPp1VdflYqLi+UOzSx2795d6f/7UaNGSZIkpsLPnTtXCg4OllxcXKR+/fpJCQkJ8gZtYtW9B4mJiVX+bNy9e7fcoZtETd8Dd1PaNHiVJNnpMqhEREREVWARNBERESkOEyAiIiJSHCZAREREpDhMgIiIiEhxmAARERGR4jABIiIiIsVhAkRERESKwwSIiKgSe/bsgUqlQlZWltyhEJEZMAEiIiIixWECRERERIrDBIiIrJJWq8XChQsRGRkJNzc3dOzYERs2bABQPjy1ZcsWdOjQAa6urujevTtOnz5tdI3vv/8e7du3h4uLCyIiIrB48WKjrxcXF2PWrFkIDw+Hi4sLWrZsic8//9zonOPHj6NLly5wd3dHz549kZCQoP/ayZMn0bdvX3h6esLLywuxsbE4duyYmd4RIjIlJkBEZJUWLlyIdevWYfny5Thz5gymT5+OESNGYO/evfpzZs6cicWLF+Po0aMIDAzEkCFDUFpaCkAkLk8//TSeeeYZnDp1Cq+//jrmzp2LNWvW6B8/cuRIfP3111i6dCnOnTuHzz77DI0aNTKK49VXX8XixYtx7NgxODo6Gu0e/9xzz6FJkyY4evQojh8/jtmzZ8PJycm8bwwRmYbcu7ESEd2tqKhIcnd3lw4cOGB0fOzYsdLw4cP1u1x/8803+q/dvn1bcnNzk9avXy9JkiQ9++yz0oMPPmj0+JkzZ0pRUVGSJElSQkKCBEDauXNnpTHonuPXX3/VH9uyZYsEQCosLJQkSZI8PT2lNWvWNPwFE5HFsQeIiKzOpUuXUFBQgAcffBCNGjXS39atW4fLly/rz+vRo4e+7efnhzZt2uDcuXMAgHPnzqFXr15G1+3VqxcuXrwIjUaDEydOQK1Wo3fv3tXG0qFDB307NDQUAJCamgoAmDFjBsaNG4f+/ftj0aJFRrERkXVjAkREVicvLw8AsGXLFpw4cUJ/O3v2rL4OqKHc3NxqdZ7hkJZKpQIg6pMA4PXXX8eZM2cwePBg/Pbbb4iKisLGjRtNEh8RmRcTICKyOlFRUXBxccG1a9fQsmVLo1t4eLj+vEOHDunbmZmZuHDhAtq1awcAaNeuHfbv32903f3796N169ZQq9WIiYmBVqs1qimqj9atW2P69OnYsWMHHn/8caxevbpB1yMiy3CUOwAiort5enri5ZdfxvTp06HVanHfffchOzsb+/fvh5eXF5o1awYAeOONN+Dv74/g4GC8+uqrCAgIwNChQwEAL730Erp27Yo333wTw4YNw8GDB/Hxxx/j008/BQBERERg1KhRGDNmDJYuXYqOHTvi6tWrSE1NxdNPP11jjIWFhZg5cyaefPJJREZG4saNGzh69CieeOIJs70vRGRCchchERFVRqvVSh988IHUpk0bycnJSQoMDJTi4uKkvXv36guUN2/eLLVv315ydnaW7r33XunkyZNG19iwYYMUFRUlOTk5SU2bNpXee+89o68XFhZK06dPl0JDQyVnZ2epZcuW0qpVqyRJKi+CzszM1J//xx9/SACkxMREqbi4WHrmmWek8PBwydnZWQoLC5MmT56sL5AmIuumkiRJkjkHIyKqkz179qBv377IzMyEj4+P3OEQkQ1iDRAREREpDhMgIiIiUhwOgREREZHisAeIiIiIFIcJEBERESkOEyAiIiJSHCZAREREpDhMgIiIiEhxmAARERGR4jABIiIiIsVhAkRERESKwwSIiIiIFOf/AQe6yM/LEikhAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "project.plot_episodes(\n",
     "    [\"test_best\"],\n",
@@ -844,72 +339,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EVALUATION test_best\n",
-      "episode test_best\n",
-      "Number of samples:\n",
-      "    validation:\n",
-      "      {-100: 161290, 0: 707, 2: 42341, 3: 27320, 1: 7446}\n",
-      "    training:\n",
-      "      {-100: 649094, 2: 163336, 0: 2374, 3: 92604, 1: 26480}\n",
-      "    test:\n",
-      "      {1: 0, 2: 0, 3: 0, 0: 0}\n",
-      "Setting loaded normalization statistics...\n",
-      "Initializing class weights:\n",
-      "    0.768, 0.069, 0.011, 0.02\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  0%|          | 0/8 [00:00<?, ?it/s]/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning:\n",
-      "\n",
-      "__floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "\n",
-      "100%|██████████| 8/8 [00:16<00:00,  2.08s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "AGGREGATED:\n",
-      "f1_0 0.652, f1_1 0.562, f1_2 0.935, f1_3 0.792, mAP 0.160, segmental_f1 0.195\n",
-      "Inference time: 0:00:16\n",
-      "\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'segmental_f1': 0.19543121755123138,\n",
-       " 'mAP': 0.16007250271489554,\n",
-       " 'f1_0': 0.652375340461731,\n",
-       " 'f1_1': 0.5615978240966797,\n",
-       " 'f1_2': 0.9347875714302063,\n",
-       " 'f1_3': 0.7916250228881836}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "project.evaluate(\n",
     "    [\"test_best\"],\n",
@@ -926,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using trained models"
+    "### Using trained models"
    ]
   },
   {
@@ -947,83 +379,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PREDICTION test_best_prediction\n",
-      "episode test_best\n",
-      "Computing input features...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:23<00:00,  1.16s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Computing annotation arrays...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 20/20 [00:00<00:00, 27.94it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Filtering 4.34% of samples\n",
-      "Number of samples:\n",
-      "    validation:\n",
-      "      {1: 0, 2: 0, 3: 0, 0: 0}\n",
-      "    training:\n",
-      "      {-100: 810384, 2: 205677, 0: 3081, 3: 119924, 1: 33926}\n",
-      "    test:\n",
-      "      {1: 0, 2: 0, 3: 0, 0: 0}\n",
-      "Setting loaded normalization statistics...\n",
-      "Initializing class weights:\n",
-      "    0.744, 0.068, 0.011, 0.019\n",
-      "Behavior indices:\n",
-      "    0: other\n",
-      "    1: Grooming\n",
-      "    2: Supported\n",
-      "    3: Unsupported\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "  0%|          | 0/36 [00:00<?, ?it/s]/home/liza/DLC2Action_minimal/dlc2action/model/c2f_tcn.py:93: UserWarning:\n",
-      "\n",
-      "__floordiv__ is deprecated, and its behavior will change in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values. To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor').\n",
-      "\n",
-      "100%|██████████| 36/36 [01:08<00:00,  1.89s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "project.run_prediction(\n",
     "    \"test_best_prediction\",\n",
@@ -1034,18 +392,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ind0: torch.Size([4, 15227])\n",
-      "The mean probability of Unsupported between frames 50 and 70 is 2.8996411856496707e-05\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pickle\n",
     "import os\n",
@@ -1083,43 +432,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Removing datasets...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 7/7 [00:12<00:00,  1.74s/it]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "project.remove_saved_features()\n",
     "project.remove_extra_checkpoints()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Makes changes to the minimal notebook to address #14:
- adds a pill to open the notebook with Google Colab
- downloads the OFT data from `github.com/ETHZ-INS/DLCAnalyzer`
- unpacks the OFT data to have one annotation file per video (using Pandas)

To view and test the notebook in Colab, open [colab.research.google.com/github/n-poulsen/DLC2action/blob/niels/fix_notebooks/examples/minimal_notebook.ipynb](https://colab.research.google.com/github/n-poulsen/DLC2action/blob/niels/fix_notebooks/examples/minimal_notebook.ipynb)

The same fixes/updates should be made to the `demo_notebook` if these ones are accepted.